### PR TITLE
Add support for two classes of clients experiment

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -78,7 +78,7 @@ fi
 #   -s	replace read with short scan (100 elements)
 #   -l local read
 if [ "${TYPE}" == "client" ]; then
-    args="-clients ${CLIENTS} -maddr ${MADDR} -mport ${MPORT} ${CLIENT_EXTRA_ARGS}"
+    args="-maddr ${MADDR} -mport ${MPORT} ${CLIENT_EXTRA_ARGS}"
 
     # aggregate all logs in a single file
     ALL=all_logs

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -59,11 +59,9 @@ fi
 
 # Usage of ./bin/client:
 #   -c int
-#     	Percentage of conflicts. Defaults to 0%
+#     	Percentage of conflicts. Defaults to 0. If the conflict rate is 142, two classes of clients (conflict and non-conflicting) are created.
 #   -e	Egalitarian (no leader).
 #   -f	Fast Paxos: send message directly to all replicas.
-#   -id string
-#     	the id of the client. Default is RFC 4122 nodeID.
 #   -maddr string
 #     	Master address. Defaults to localhost
 #   -mport int
@@ -80,7 +78,7 @@ fi
 #   -s	replace read with short scan (100 elements)
 #   -l local read
 if [ "${TYPE}" == "client" ]; then
-    args="-maddr ${MADDR} -mport ${MPORT} ${CLIENT_EXTRA_ARGS}"
+    args="-clients ${CLIENTS} -maddr ${MADDR} -mport ${MPORT} ${CLIENT_EXTRA_ARGS}"
 
     # aggregate all logs in a single file
     ALL=all_logs
@@ -89,7 +87,7 @@ if [ "${TYPE}" == "client" ]; then
     mkdir -p logs/
 
     for i in $(seq 1 ${NCLIENTS}); do
-        ${DIR}/client ${args} 2>&1 | tee -a logs/c_${i}.txt ${ALL} >/dev/null &
+        ${DIR}/client -id ${i} ${args} 2>&1 | tee -a logs/c_${i}.txt ${ALL} >/dev/null &
         echo "> Client $i of ${NCLIENTS} started!"
     done
 

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -13,7 +13,6 @@ import (
 )
 
 var id *int = flag.Int("id", 1, "The id of the client.")
-var clients *int = flag.Int("clients", 0, "Total number of clients.")
 var masterAddr *string = flag.String("maddr", "", "Master address. Defaults to localhost")
 var masterPort *int = flag.Int("mport", 7087, "Master port. ")
 var reqsNb *int = flag.Int("q", 1000, "Total number of requests. ")
@@ -73,7 +72,7 @@ func main() {
 
 		if *conflicts == 142 {
 			// two-class experiment
-			if client % 2 == 0 {
+			if *id % 2 == 0 {
 				karray[i] = 42
 			}
 		} else {

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -34,10 +34,6 @@ func main() {
 
 	rand.Seed(time.Now().UnixNano())
 
-	if *conflicts > 100 {
-		log.Fatalf("Conflicts percentage must be between 0 and 100.\n")
-	}
-
 	var proxy *bindings.Parameters
 	for {
 		proxy = bindings.NewParameters(*masterAddr, *masterPort, *verbose, *noLeader, *fast, *localReads)

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -49,13 +49,14 @@ func main() {
 		proxy.Disconnect()
 	}
 
-	log.Printf("client: %v (verbose=%v, psize=%v, conflicts=%v)", *id, *verbose, *psize, *conflicts)
+	blackColor := *conflicts == 142 && *id <= *clients/2
+
+	log.Printf("client: %v (verbose=%v, psize=%v, conflicts=%v, black color=%v)", *id, *verbose, *psize, *conflicts, blackColor)
 
 	karray := make([]state.Key, *reqsNb)
 	put := make([]bool, *reqsNb)
 
 	clientKey := state.Key(uint64(uuid.New().Time())) // a command id unique to this client.
-	blackColor := *conflicts == 142 && *id <= *clients/2
 
 	for i := 0; i < *reqsNb; i++ {
 		put[i] = false


### PR DESCRIPTION
If the conflict rate is 142, two classes of clients are created:
- half of the clients issue non-conflicting commands
- the other half, issues conflicting commands